### PR TITLE
Feature/changeable sign text

### DIFF
--- a/autoload/qfsigns.vim
+++ b/autoload/qfsigns.vim
@@ -2,11 +2,12 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 "variable {{{
-let g:qfsigns#Enabled   = ! exists('g:qfsigns#Enabled')   ? 1 : g:qfsigns#Enabled
-let g:qfsigns#AutoJump  = ! exists('g:qfsigns#AutoJump')  ? 0 : g:qfsigns#AutoJump
+let g:qfsigns#Enabled    = ! exists('g:qfsigns#Enabled')    ? 1    : g:qfsigns#Enabled
+let g:qfsigns#AutoJump   = ! exists('g:qfsigns#AutoJump')   ? 0    : g:qfsigns#AutoJump
+let g:qfsigns#SignSymbol = ! exists('g:qfsigns#SignSymbol') ? '>>' : g:qfsigns#SignSymbol
 if !exists('g:qfsigns#Config')
     let g:qfsigns#Config = {'id': '5050', 'name': 'QFError',}
-    execute 'sign define '.get(g:qfsigns#Config,'name').' linehl=SpellBad texthl=SpellBad text=>>'
+    execute 'sign define '.get(g:qfsigns#Config,'name').' linehl=SpellBad texthl=SpellBad text='.g:qfsigns#SignSymbol
     lockvar! g:qfsigns#Config
 endif
 "}}}

--- a/autoload/qfsigns.vim
+++ b/autoload/qfsigns.vim
@@ -2,12 +2,12 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 "variable {{{
-let g:qfsigns#Enabled    = ! exists('g:qfsigns#Enabled')    ? 1    : g:qfsigns#Enabled
-let g:qfsigns#AutoJump   = ! exists('g:qfsigns#AutoJump')   ? 0    : g:qfsigns#AutoJump
-let g:qfsigns#SignSymbol = ! exists('g:qfsigns#SignSymbol') ? '>>' : g:qfsigns#SignSymbol
+let g:qfsigns#Enabled  = ! exists('g:qfsigns#Enabled')  ? 1    : g:qfsigns#Enabled
+let g:qfsigns#AutoJump = ! exists('g:qfsigns#AutoJump') ? 0    : g:qfsigns#AutoJump
+let g:qfsigns#SignText = ! exists('g:qfsigns#SignText') ? '>>' : g:qfsigns#SignText
 if !exists('g:qfsigns#Config')
     let g:qfsigns#Config = {'id': '5050', 'name': 'QFError',}
-    execute 'sign define '.get(g:qfsigns#Config,'name').' linehl=SpellBad texthl=SpellBad text='.g:qfsigns#SignSymbol
+    execute 'sign define '.get(g:qfsigns#Config,'name').' linehl=SpellBad texthl=SpellBad text='.g:qfsigns#SignText
     lockvar! g:qfsigns#Config
 endif
 "}}}


### PR DESCRIPTION
Enable to change sign text like a Syntastic.
https://github.com/vim-syntastic/syntastic/blob/master/doc/syntastic.txt#L411-L424

# e.g.

```vimrc
let g:qfsigns#SignText = '❗️'
```

![screen shot 2016-12-20 at 12 17 52](https://cloud.githubusercontent.com/assets/12206768/21337243/05845d88-c6af-11e6-8b92-724b197f2f15.png)
